### PR TITLE
User Identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,13 @@ The page served is `example/index.html`. You can change the framework by configu
 
 `npm start`
 
-The local server can be used by your local instance of [guardian frontend](https://github.com/guardian/frontend) by updating your `frontend.properties`.
+The local server can be used by your local instance of [guardian frontend](https://github.com/guardian/frontend) by updating your `frontend.conf`.
 
-`discussion.frontend.assetsMap=http://localhost:4000/assets-v1.0.0.json`
+```
+devOverrides {
+    discussion.frontend.assetsMap="http://localhost:4000/assets-{VERSION}.json"
+}
+```
 
 This serves the production version of discussion assets.
 

--- a/example/example.js
+++ b/example/example.js
@@ -2,8 +2,10 @@ import CommentLoader from '../src/index';
 
 const beforeLoad = performance.now();
 CommentLoader({
+    apiHost: '/api',
     discussionId: '1234',
-    element: document.getElementById('comments-container')
+    element: document.getElementById('comments-container'),
+    user: null
 })
 .then(mediator => {
     mediator.once('comment-count', () => {

--- a/example/example.js
+++ b/example/example.js
@@ -1,4 +1,5 @@
 import CommentLoader from '../src/index';
+import { unmountComponentAtNode } from 'react-dom';
 
 const loadedComponents = [];
 const allKeys = ['closed', 'anon', 'banned', 'provided'];
@@ -73,6 +74,7 @@ function controlsFromStorage () {
             json[key] = document.getElementById(key).checked;
         });
         loadedComponents.forEach(props => {
+            unmountComponentAtNode(props.element);
             props.element.innerHTML = '';
             CommentLoader(propsFromStorage(props, json));
         });

--- a/example/index.html
+++ b/example/index.html
@@ -5,8 +5,29 @@
         <meta http-equiv="x-ua-compatible" content="ie=edge">
         <title>Discussion</title>
         <script src="example.js?framework=react&production=false" defer async></script>
+        <link rel="stylesheet" href="style.css">
     </head>
     <body>
-        <div id="comments-container"></div>
+        <nav class="display-controls">
+            <label class="option">
+                <input id="closed" type="checkbox">
+                <span>Closed</span>
+            </label>
+            <label class="option">
+                <input id="anon" type="checkbox">
+                <span>Anonymous</span>
+            </label>
+        </nav>
+        <div class="mobile-view">
+            <div class="portrait">
+                <div id="comments-container-portrait"></div>
+            </div>
+            <div class="landscape">
+                <div id="comments-container-landscape"></div>
+            </div>
+        </div>
+        <div class="large-view">
+            <div id="comments-container-large"></div>
+        </div>
     </body>
 </html>

--- a/example/index.html
+++ b/example/index.html
@@ -17,6 +17,14 @@
                 <input id="anon" type="checkbox">
                 <span>Anonymous</span>
             </label>
+            <label class="option">
+                <input id="provided" type="checkbox">
+                <span>User: Fabio</span>
+            </label>
+            <label class="option">
+                <input id="banned" type="checkbox">
+                <span>Banned</span>
+            </label>
         </nav>
         <div class="mobile-view">
             <div class="portrait">

--- a/example/lib/mocks.js
+++ b/example/lib/mocks.js
@@ -11,10 +11,10 @@ app.get('/getCommentCounts', (req, res) => {
 app.get('/profile/:id', (req, res) => {
     switch (req.params.id) {
         case 'me':
-            res.send(userResponse('Your Self'));
+            res.jsonp(userResponse('Your Self'));
             break;
         default:
-            res.send({
+            res.jsonp({
                 'status': 'error',
                 'statusCode': 400,
                 'message': 'You must be signed in to view this page',

--- a/example/lib/mocks.js
+++ b/example/lib/mocks.js
@@ -1,0 +1,52 @@
+const express = require('express');
+
+const app = express();
+
+app.get('/getCommentCounts', (req, res) => {
+    res.send(req.query['short-urls'].split(',').reduce((resp, id) => {
+        return Object.assign(resp, { [id]: Math.floor(Math.random() * 5000) });
+    }, {}));
+});
+
+app.get('/profile/:id', (req, res) => {
+    switch (req.params.id) {
+        case 'me':
+            res.send(userResponse('Your Self'));
+            break;
+        default:
+            res.send({
+                'status': 'error',
+                'statusCode': 400,
+                'message': 'You must be signed in to view this page',
+                'errorCode': 'NOT_SIGNED_IN'
+            });
+            break;
+    }
+});
+
+function userResponse (name) {
+    const id = name.split('').reduce((sum, character) => 2 * sum + character.charCodeAt(0), Math.floor(Math.random() * 10) + 1);
+
+    return {
+        status: 'ok',
+        userProfile: {
+            userId: '' + id,
+            displayName: name,
+            webUrl: 'https://profile.theguardian.com/user/id/' + id,
+            apiUrl: 'https://discussion.guardianapis.com/discussion-api/profile/' + id,
+            avatar: 'https://avatar.guim.co.uk/user/' + id,
+            secureAvatarUrl: 'https://avatar.guim.co.uk/user/' + id,
+            badge: [],
+            details: {},
+            privateFields: {
+                internalId: Math.floor(id / 2),
+                canPostComment: true,
+                isPremoderated: false,
+                isSocial: true,
+                hasCommented: true
+            }
+        }
+    };
+}
+
+module.exports = app;

--- a/example/server.js
+++ b/example/server.js
@@ -10,6 +10,7 @@ const rollup = require('rollup');
 const uglify = require('uglify-js');
 const uglifyOpts = require('../uglify.options');
 const pkg = require('../package.json');
+const mockApi = require('./lib/mocks');
 
 const app = express();
 
@@ -78,11 +79,7 @@ app.get('/assets-v' + pkg.version + '.json', (req, res) => {
     });
 });
 
-app.get('/getCommentCounts', (req, res) => {
-    res.send(req.query['short-urls'].split(',').reduce((resp, id) => {
-        return Object.assign(resp, { [id]: Math.floor(Math.random() * 5000) });
-    }, {}));
-});
+app.use('/api', mockApi);
 
 var port = process.env.PORT || 4000;
 app.listen(port, () => {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "guardian-discussion-frontend",
   "projectName": "Discussion::discussion-frontend",
   "description": "Standalone UI for Guardian comments",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "license": "Apache-2.0",
   "repository": "https://github.com/guardian/discussion-frontend",
   "files": [

--- a/rollup.base.config.js
+++ b/rollup.base.config.js
@@ -14,8 +14,8 @@ const base = [
     }),
     commonjs({
         namedExports: {
-            'node_modules/react/lib/ReactDOM.js': ['render'],
-            'preact-compat': ['render'],
+            'node_modules/react/lib/ReactDOM.js': ['render', 'unmountComponentAtNode'],
+            'preact-compat': ['render', 'unmountComponentAtNode'],
             'preact': ['render']
         }
     })
@@ -37,6 +37,9 @@ const production = [
     replace({
         'process.env.NODE_ENV': '\'production\'',
         'typeof process': '\'undefined\''
+    }),
+    alias({
+        '../model/proptypes': path.join(__dirname, 'src/model/proptypes-prod.js')
     }),
     babel({
         comments: false,

--- a/src/index.js
+++ b/src/index.js
@@ -5,16 +5,22 @@ import { create as createApi } from './net/discussion-api.js';
 
 export default function create ({
     apiHost,
+    profileUrl,
     discussionId,
-    closed = false,
-    element
+    closed,
+    element,
+    user,
+    userFromCookie
 }) {
     const api = createApi({ apiHost });
     const component = (
         <Discussion
             id={discussionId}
             api={api}
+            profileUrl={profileUrl}
             closed={closed}
+            user={user}
+            userFromCookie={userFromCookie}
         />
     );
 

--- a/src/index.js
+++ b/src/index.js
@@ -6,16 +6,21 @@ import { create as createApi } from './net/discussion-api.js';
 export default function create ({
     apiHost,
     discussionId,
+    closed = false,
     element
 }) {
     const api = createApi({ apiHost });
+    const component = (
+        <Discussion
+            id={discussionId}
+            api={api}
+            closed={closed}
+        />
+    );
 
     return new Promise(resolve => {
         render(
-            <Discussion
-                id={discussionId}
-                api={api}
-            />,
+            component,
             element,
             () => resolve(mediator)
         );

--- a/src/model/discussion.js
+++ b/src/model/discussion.js
@@ -1,28 +1,51 @@
-import CommentCount from '../ui/comment-count';
+import DiscussionView from '../ui/discussion-view';
 import mediator from '../utils/mediator';
+import sharedPropTypes from './proptypes';
 
 class Discussion extends React.Component {
     constructor (props) {
         super(props);
         this.state = {
-            commentsCount: 0
+            commentsCount: 0,
+            profile: null,
+            anonymous: true
         };
         this.api = this.props.api;
     }
 
     componentDidMount () {
-        this.api.commentCount(this.props.id)
+        this.getCommentCount();
+        this.getUser();
+    }
+
+    getCommentCount () {
+        const { id } = this.props;
+
+        this.api.commentCount(id)
         .then(counts => {
-            const value = counts[this.props.id] || 0;
+            const value = counts[id] || 0;
             this.setState({ commentsCount: value }, () => {
                 mediator.emit('comment-count', value);
             });
         });
     }
 
+    getUser () {
+        const { user, userFromCookie } = this.props;
+        if (userFromCookie) {
+            this.api.userProfile().then((profile) => {
+                this.setState({ profile: profile, anonymous: false });
+            });
+        } else if (user) {
+            this.setState({ profile: user, anonymous: false });
+        } else {
+            this.setState({ anonymous: true });
+        }
+    }
+
     render () {
         return (
-            <CommentCount count={this.state.commentsCount} />
+            <DiscussionView {...this.state} id={this.props.id} closed={this.props.closed} />
         );
     }
 }
@@ -30,8 +53,12 @@ class Discussion extends React.Component {
 Discussion.propTypes = {
     id: React.PropTypes.string.isRequired,
     api: React.PropTypes.shape({
-        commentCount: React.PropTypes.func.isRequired
-    }).isRequired
+        commentCount: React.PropTypes.func.isRequired,
+        userProfile: React.PropTypes.func.isRequired
+    }).isRequired,
+    user: sharedPropTypes.user,
+    userFromCookie: React.PropTypes.bool,
+    closed: React.PropTypes.bool.isRequired
 };
 
 export default Discussion;

--- a/src/model/discussion.js
+++ b/src/model/discussion.js
@@ -1,6 +1,6 @@
 import DiscussionView from '../ui/discussion-view';
 import mediator from '../utils/mediator';
-import sharedPropTypes from './proptypes';
+import sharedPropTypes from '../model/proptypes';
 
 class Discussion extends React.Component {
     constructor (props) {
@@ -45,7 +45,12 @@ class Discussion extends React.Component {
 
     render () {
         return (
-            <DiscussionView {...this.state} id={this.props.id} closed={this.props.closed} />
+            <DiscussionView
+                {...this.state}
+                id={this.props.id}
+                closed={this.props.closed}
+                profileUrl={this.props.profileUrl}
+            />
         );
     }
 }
@@ -56,6 +61,7 @@ Discussion.propTypes = {
         commentCount: React.PropTypes.func.isRequired,
         userProfile: React.PropTypes.func.isRequired
     }).isRequired,
+    profileUrl: React.PropTypes.string.isRequired,
     user: sharedPropTypes.user,
     userFromCookie: React.PropTypes.bool,
     closed: React.PropTypes.bool.isRequired

--- a/src/model/proptypes-prod.js
+++ b/src/model/proptypes-prod.js
@@ -1,0 +1,1 @@
+export const user = null;

--- a/src/model/proptypes.js
+++ b/src/model/proptypes.js
@@ -1,7 +1,5 @@
-export default {
-    user: React.PropTypes.shape({
-        privateFields: React.PropTypes.shape({
-            canPostComment: React.PropTypes.bool
-        })
+export const user = React.PropTypes.shape({
+    privateFields: React.PropTypes.shape({
+        canPostComment: React.PropTypes.bool
     })
-};
+});

--- a/src/model/proptypes.js
+++ b/src/model/proptypes.js
@@ -1,0 +1,7 @@
+export default {
+    user: React.PropTypes.shape({
+        privateFields: React.PropTypes.shape({
+            canPostComment: React.PropTypes.bool
+        })
+    })
+};

--- a/src/net/discussion-api.js
+++ b/src/net/discussion-api.js
@@ -1,4 +1,4 @@
-import { getJson } from '../utils/json';
+import { getJson, jsonp } from '../utils/json';
 import mediator from '../utils/mediator';
 import { join } from '../utils/url';
 
@@ -15,7 +15,7 @@ export function create ({
 
     function userProfile (id = 'me') {
         const url = join(apiHost, '/profile/' + id);
-        return get(url, true)
+        return jsonp(url)
         .then(response => {
             if (response.status !== 'ok') {
                 throw new Error('Invalid user profile status: ' + response.status);

--- a/src/net/discussion-api.js
+++ b/src/net/discussion-api.js
@@ -13,7 +13,24 @@ export function create ({
         });
     }
 
+    function userProfile (id = 'me') {
+        const url = join(apiHost, '/profile/' + id);
+        return get(url, true)
+        .then(response => {
+            if (response.status !== 'ok') {
+                throw new Error('Invalid user profile status: ' + response.status);
+            } else {
+                return response.userProfile;
+            }
+        })
+        .catch(ex => {
+            mediator.emit('error', 'user-profile', ex);
+            throw ex;
+        });
+    }
+
     return {
-        commentCount
+        commentCount,
+        userProfile
     };
 }

--- a/src/ui/comment-count.js
+++ b/src/ui/comment-count.js
@@ -1,10 +1,12 @@
 const CommentCount = ({ count }) => {
     if (count) {
         return (
-            <span>comments <span className="discussion__comment-count">({count})</span></span>
+            <h2 className="container__meta__title">
+                comments <span className="discussion__comment-count">({count})</span>
+            </h2>
         );
     } else {
-        return <span>comments</span>;
+        return <h2 className="container__meta__title">comments</h2>;
     }
 };
 

--- a/src/ui/discussion-view.js
+++ b/src/ui/discussion-view.js
@@ -1,24 +1,34 @@
 import CommentCount from '../ui/comment-count';
+import Identity from '../ui/identity';
 import sharedPropTypes from '../model/proptypes';
 
 const DiscussionView = function({
-    id,
+    anonymous,
     closed,
     commentsCount,
     profile,
-    anonymous
+    profileUrl
 }) {
     return (
-        <CommentCount count={commentsCount} />
+        <div className="container__meta">
+            <CommentCount count={commentsCount} />
+            <Identity
+                anonymous={anonymous}
+                closed={closed}
+                profile={profile}
+                profileUrl={profileUrl}
+            />
+        </div>
     );
 };
 
 DiscussionView.propTypes = {
-    commentsCount: React.PropTypes.number,
-    profile: sharedPropTypes.user,
     anonymous: React.PropTypes.bool,
-    id: React.PropTypes.string.isRequired,
-    closed: React.PropTypes.bool.isRequired
+    closed: React.PropTypes.bool,
+    commentsCount: React.PropTypes.number,
+    id: React.PropTypes.string,
+    profile: sharedPropTypes.user,
+    profileUrl: React.PropTypes.string.isRequired
 };
 
 export default DiscussionView;

--- a/src/ui/discussion-view.js
+++ b/src/ui/discussion-view.js
@@ -1,0 +1,24 @@
+import CommentCount from '../ui/comment-count';
+import sharedPropTypes from '../model/proptypes';
+
+const DiscussionView = function({
+    id,
+    closed,
+    commentsCount,
+    profile,
+    anonymous
+}) {
+    return (
+        <CommentCount count={commentsCount} />
+    );
+};
+
+DiscussionView.propTypes = {
+    commentsCount: React.PropTypes.number,
+    profile: sharedPropTypes.user,
+    anonymous: React.PropTypes.bool,
+    id: React.PropTypes.string.isRequired,
+    closed: React.PropTypes.bool.isRequired
+};
+
+export default DiscussionView;

--- a/src/ui/discussion-view.js
+++ b/src/ui/discussion-view.js
@@ -1,6 +1,6 @@
 import CommentCount from '../ui/comment-count';
 import Identity from '../ui/identity';
-import sharedPropTypes from '../model/proptypes';
+import { user } from '../model/proptypes';
 
 const DiscussionView = function({
     anonymous,
@@ -27,7 +27,7 @@ DiscussionView.propTypes = {
     closed: React.PropTypes.bool,
     commentsCount: React.PropTypes.number,
     id: React.PropTypes.string,
-    profile: sharedPropTypes.user,
+    profile: user,
     profileUrl: React.PropTypes.string.isRequired
 };
 

--- a/src/ui/identity.js
+++ b/src/ui/identity.js
@@ -1,0 +1,43 @@
+import sharedPropTypes from '../model/proptypes';
+
+const Identity = function({
+    anonymous,
+    closed,
+    profile,
+    profileUrl
+}) {
+    if (anonymous || !profile) {
+        return (
+            <p className="container__meta__item">
+                <a className="u-underline" href={profileUrl + '/signin?INTCMP=DOTCOM_COMMENTS_SIGNIN'}>Sign in</a>
+                {' '}or{' '}
+                <a className="u-underline" href={profileUrl + '/register?INTCMP=DOTCOM_COMMENTS_REG'}>create your Guardian account</a>
+                {' '}to join the discussion.
+            </p>
+        );
+    } else if (closed) {
+        return (
+            <p className="container__meta__item">
+                This discussion is closed for comments.
+            </p>
+        );
+    } else if ((profile.privateFields || {}).canPostComment === false) {
+        return (
+            <p className="container__meta__item d-discussion__error">
+                Commenting has been disabled for this account (<a href="/community-faqs#321a">why?</a>)
+            </p>
+        );
+    } else {
+        // Ideally the avatar goes here, but for now it's still in the comment box
+        return null;
+    }
+};
+
+Identity.propTypes = {
+    anonymous: React.PropTypes.bool,
+    closed: React.PropTypes.bool,
+    profile: sharedPropTypes.user,
+    profileUrl: React.PropTypes.string.isRequired
+};
+
+export default Identity;

--- a/src/ui/identity.js
+++ b/src/ui/identity.js
@@ -1,4 +1,4 @@
-import sharedPropTypes from '../model/proptypes';
+import { user } from '../model/proptypes';
 
 const Identity = function({
     anonymous,
@@ -36,7 +36,7 @@ const Identity = function({
 Identity.propTypes = {
     anonymous: React.PropTypes.bool,
     closed: React.PropTypes.bool,
-    profile: sharedPropTypes.user,
+    profile: user,
     profileUrl: React.PropTypes.string.isRequired
 };
 

--- a/src/utils/json.js
+++ b/src/utils/json.js
@@ -1,8 +1,21 @@
-export function getJson (path, includeCredentials) {
+export function getJson (path) {
     return fetch(path, {
-        mode: 'cors',
-        credentials: includeCredentials ? 'include' : 'same-origin'
+        mode: 'cors'
     }).then(resp => {
         return resp.ok ? resp.json() : Promise.reject(new Error('fetch error: ' + resp.statusText));
+    });
+}
+
+export function jsonp (path) {
+    return new Promise(function(resolve, reject) {
+        const jsonpCallback = 'jp_' + Math.floor((Math.random() * 100)) + new Date().getTime();
+        const jsonpPath = [path, 'callback=' + jsonpCallback].join(path.indexOf('?') === -1 ? '?' : '&');
+        window[jsonpCallback] = resolve;
+        const script = document.createElement('script');
+        script.src = jsonpPath;
+        script.onerror = function() {
+            reject(new Error('JSONP network error on ' + jsonpPath));
+        };
+        document.head.appendChild(script);
     });
 }

--- a/src/utils/json.js
+++ b/src/utils/json.js
@@ -1,6 +1,7 @@
-export function getJson (path) {
+export function getJson (path, includeCredentials) {
     return fetch(path, {
-        mode: 'cors'
+        mode: 'cors',
+        credentials: includeCredentials ? 'include' : 'same-origin'
     }).then(resp => {
         return resp.ok ? resp.json() : Promise.reject(new Error('fetch error: ' + resp.statusText));
     });

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -1,3 +1,3 @@
 export function join (...paths) {
-    return paths.join('/').replace(/\/+/g, '/');
+    return paths.join('/').replace(/([^:])\/+/g, '$1/');
 }


### PR DESCRIPTION
This changes the contract with frontend, hence the version `1.1`.

Move the side bar of comments to discussion frontend

![screen shot 2016-08-31 at 18 13 19](https://cloud.githubusercontent.com/assets/680284/18138856/a5b59052-6fa6-11e6-85a9-39485c2e09dd.png)

There's one difference with the version on frontend.

When the user is __not logged id and the discussion is closed__
* `frontend` shows `This discussion is closed for comments`
* `discussion-frontend` shows `Sign in or register`

It's a sign in bait. Once logged in, it'll show `This discussion is closed for comments`