### PR TITLE
Put react on a diet

### DIFF
--- a/bin/lib/check-react-type-spec-prod.js
+++ b/bin/lib/check-react-type-spec-prod.js
@@ -1,0 +1,1 @@
+module.exports = function() {};

--- a/bin/lib/react-class-prod.js
+++ b/bin/lib/react-class-prod.js
@@ -1,0 +1,1 @@
+exports.createClass = function() {};

--- a/bin/lib/react-proptypes-prod.js
+++ b/bin/lib/react-proptypes-prod.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/bin/lib/react-proptypes-secret-prod.js
+++ b/bin/lib/react-proptypes-secret-prod.js
@@ -1,0 +1,1 @@
+module.exports = 'S';

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "uglify-js": "2.7.3"
   },
   "dependencies": {
-    "preact": "5.6.0",
+    "preact": "6.0.1",
     "preact-compat": "3.0.0",
     "react": "15.3.1",
     "react-dom": "15.3.1",

--- a/rollup.base.config.js
+++ b/rollup.base.config.js
@@ -44,7 +44,8 @@ const base = [
 
 const aliasesReact = [
     alias({
-        'react-dom': path.join(__dirname, 'node_modules/react/lib/ReactDOM.js')
+        'react-dom': path.join(__dirname, 'node_modules/react/lib/ReactDOM.js'),
+        './ReactClass': path.join(__dirname, 'bin/lib/react-class-prod.js')
     })
 ];
 
@@ -60,7 +61,10 @@ const production = [
         'typeof process': '\'undefined\''
     }),
     alias({
-        '../model/proptypes': path.join(__dirname, 'src/model/proptypes-prod.js')
+        '../model/proptypes': path.join(__dirname, 'src/model/proptypes-prod.js'),
+        './checkReactTypeSpec': path.join(__dirname, 'bin/lib/check-react-type-spec-prod.js'),
+        './ReactPropTypesSecret': path.join(__dirname, 'bin/lib/react-proptypes-secret-prod.js'),
+        './ReactPropTypes': path.join(__dirname, 'bin/lib/react-proptypes-prod.js')
     }),
     babel({
         comments: false,


### PR DESCRIPTION
Define an empty alias for `React.createClass` both in `DEV` and `PROD` (I'm not using `.createClass` but ES6 classes or pure components which are converted into `.createElement`). Preact doesn't even support it anyway.

Define empty `propTypes` for `PROD`. The `PROD `version is kinda weird because `propTypes` validation does not run, but the `propTypes` are still included.
It should be safe to do so because on `PROD` I'm already stripping out `propTypes` from my components and I'm not using `context` which apparently might rely on `propTypes`.

Saves 2.2KB gzipped
