### PR TITLE
Allow to pass a custom net module

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,15 +4,24 @@ import mediator from './utils/mediator';
 import { create as createApi } from './net/discussion-api.js';
 
 export default function create ({
+    /* Base host for discussion api */
     apiHost,
-    profileUrl,
-    discussionId,
+    /* Is the discussion closed for comments */
     closed,
+    /* Discussion ID */
+    discussionId,
+    /* Element in which the discussion frontend is rendered */
     element,
+    /* Custom net module, exports `json` and `jsonp` methods */
+    net = {},
+    /* Base path for profile service (signin, register) */
+    profileUrl,
+    /* User information, if null, it tries to get it from discussion API */
     user,
+    /* Does the user have a valid guardian user cookie? If so it'll get the profile from API */
     userFromCookie
 }) {
-    const api = createApi({ apiHost });
+    const api = createApi({ apiHost, net });
     const component = (
         <Discussion
             id={discussionId}

--- a/src/net/discussion-api.js
+++ b/src/net/discussion-api.js
@@ -1,13 +1,16 @@
-import { getJson, jsonp } from '../utils/json';
+import * as defaultNet from '../utils/net';
 import mediator from '../utils/mediator';
 import { join } from '../utils/url';
 
 export function create ({
-    apiHost
-}, get = getJson) {
+    apiHost,
+    net
+}) {
+    const {json = defaultNet.json, jsonp = defaultNet.jsonp} = net;
+
     function commentCount (...ids) {
         const url = join(apiHost, 'getCommentCounts' + '?short-urls=' + ids.join(','));
-        return get(url).catch(ex => {
+        return json(url).catch(ex => {
             mediator.emit('error', 'comments-count', ex);
             throw ex;
         });

--- a/src/utils/net.js
+++ b/src/utils/net.js
@@ -1,4 +1,4 @@
-export function getJson (path) {
+export function json (path) {
     return fetch(path, {
         mode: 'cors'
     }).then(resp => {


### PR DESCRIPTION
An environment that does not have `window.fetch` or that uses a wrapper to access the network will be able to specify a custom implementation of the methods `json` and `jsonp`