### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,35 +26,35 @@
   "devDependencies": {
     "babel-plugin-external-helpers": "^6.8.0",
     "babel-plugin-transform-react-remove-prop-types": "^0.2.9",
-    "babel-preset-es2015": "^6.13.2",
+    "babel-preset-es2015": "^6.14.0",
     "babel-preset-react": "^6.11.1",
-    "eslint": "^3.3.1",
-    "eslint-plugin-react": "^6.1.1",
+    "eslint": "^3.4.0",
+    "eslint-plugin-react": "^6.2.0",
     "express": "^4.14.0",
     "is-file": "^1.0.0",
-    "junk": "^1.0.3",
+    "junk": "^2.0.0",
     "mkdirp": "^0.5.1",
     "node-riffraff-artefact": "^1.8.0",
     "postcss-modules": "^0.5.2",
     "postcss-scss": "^0.2.1",
-    "preact": "^5.6.0",
-    "preact-compat": "^2.3.0",
     "precss": "^1.4.0",
-    "react": "^15.3.0",
-    "react-dom": "^15.3.0",
-    "rollup": "^0.34.9",
+    "rollup": "^0.34.13",
     "rollup-plugin-alias": "^1.2.0",
     "rollup-plugin-babel": "^2.6.1",
-    "rollup-plugin-commonjs": "^3.3.1",
+    "rollup-plugin-commonjs": "^4.1.0",
     "rollup-plugin-inject": "^1.4.1",
     "rollup-plugin-node-resolve": "^2.0.0",
     "rollup-plugin-postcss": "^0.2.0",
     "rollup-plugin-replace": "^1.1.1",
     "stylelint": "^7.2.0",
     "stylelint-config-standard": "^13.0.0",
-    "uglify-js": "^2.7.1"
+    "uglify-js": "2.7.3"
   },
   "dependencies": {
-    "tiny-emitter": "^1.1.0"
+    "preact": "5.6.0",
+    "preact-compat": "3.0.0",
+    "react": "15.3.1",
+    "react-dom": "15.3.1",
+    "tiny-emitter": "1.1.0"
   }
 }

--- a/rollup.base.config.js
+++ b/rollup.base.config.js
@@ -28,6 +28,7 @@ const base = [
         }
     }),
     nodeResolve({
+        module: false,
         jsnext: false,
         main: true,
         preferBuiltins: true
@@ -36,7 +37,7 @@ const base = [
         namedExports: {
             'node_modules/react/lib/ReactDOM.js': ['render', 'unmountComponentAtNode'],
             'preact-compat': ['render', 'unmountComponentAtNode'],
-            'preact': ['render']
+            'preact': ['render', 'h', 'options', 'cloneElement', 'Component']
         }
     })
 ];


### PR DESCRIPTION
Interestingly enough, `rollup-plugin-commonjs` has been update to be more clever about exports, this change alone reduces the size of react bundle by 5.5kB.

rollup/rollup-plugin-commonjs#93