### PR TITLE
Hide the widget while loading

### DIFF
--- a/src/model/discussion.js
+++ b/src/model/discussion.js
@@ -6,9 +6,10 @@ class Discussion extends React.Component {
     constructor (props) {
         super(props);
         this.state = {
+            anonymous: true,
             commentsCount: 0,
-            profile: null,
-            anonymous: true
+            loading: true,
+            profile: null
         };
         this.api = this.props.api;
     }
@@ -34,12 +35,12 @@ class Discussion extends React.Component {
         const { user, userFromCookie } = this.props;
         if (userFromCookie) {
             this.api.userProfile().then((profile) => {
-                this.setState({ profile: profile, anonymous: false });
+                this.setState({ profile: profile, anonymous: false , loading: false});
             });
         } else if (user) {
-            this.setState({ profile: user, anonymous: false });
+            this.setState({ profile: user, anonymous: false, loading: false });
         } else {
-            this.setState({ anonymous: true });
+            this.setState({ anonymous: true, loading: false });
         }
     }
 

--- a/src/ui/discussion-view.js
+++ b/src/ui/discussion-view.js
@@ -6,6 +6,7 @@ const DiscussionView = function({
     anonymous,
     closed,
     commentsCount,
+    loading,
     profile,
     profileUrl
 }) {
@@ -15,6 +16,7 @@ const DiscussionView = function({
             <Identity
                 anonymous={anonymous}
                 closed={closed}
+                loading={loading}
                 profile={profile}
                 profileUrl={profileUrl}
             />
@@ -27,6 +29,7 @@ DiscussionView.propTypes = {
     closed: React.PropTypes.bool,
     commentsCount: React.PropTypes.number,
     id: React.PropTypes.string,
+    loading: React.PropTypes.bool.isRequired,
     profile: user,
     profileUrl: React.PropTypes.string.isRequired
 };

--- a/src/ui/identity.js
+++ b/src/ui/identity.js
@@ -4,10 +4,14 @@ import styleHelpers from '../ui/styles/helpers.css';
 const Identity = function({
     anonymous,
     closed,
+    loading,
     profile,
     profileUrl
 }) {
-    if (anonymous || !profile) {
+    if (loading) {
+        // While loading don't show anything, it conflicts with what's rendered by frontend
+        return null;
+    } else if (anonymous || !profile) {
         return (
             <p className="container__meta__item">
                 <a className={styleHelpers.underline} href={profileUrl + '/signin?INTCMP=DOTCOM_COMMENTS_SIGNIN'}>Sign in</a>
@@ -37,6 +41,7 @@ const Identity = function({
 Identity.propTypes = {
     anonymous: React.PropTypes.bool,
     closed: React.PropTypes.bool,
+    loading: React.PropTypes.bool.isRequired,
     profile: user,
     profileUrl: React.PropTypes.string.isRequired
 };


### PR DESCRIPTION
By default everyone is anonymous until the data is fetched from the server. This conflicts with frontend which might have already rendenred the avatar on top of the text saying we shuold sign in.

While loading don't show anything