### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "babel-plugin-transform-react-remove-prop-types": "^0.2.9",
     "babel-preset-es2015": "^6.14.0",
     "babel-preset-react": "^6.11.1",
-    "eslint": "^3.4.0",
-    "eslint-plugin-react": "^6.2.0",
+    "eslint": "^3.5.0",
+    "eslint-plugin-react": "^6.2.2",
     "express": "^4.14.0",
     "is-file": "^1.0.0",
     "junk": "^2.0.0",
@@ -37,9 +37,9 @@
     "node-riffraff-artefact": "^1.8.0",
     "postcss-calc": "^5.3.1",
     "postcss-modules": "^0.5.2",
-    "postcss-scss": "^0.2.1",
+    "postcss-scss": "^0.3.0",
     "precss": "^1.4.0",
-    "rollup": "^0.34.13",
+    "rollup": "^0.35.11",
     "rollup-plugin-alias": "^1.2.0",
     "rollup-plugin-babel": "^2.6.1",
     "rollup-plugin-commonjs": "^4.1.0",
@@ -52,8 +52,8 @@
     "uglify-js": "2.7.3"
   },
   "dependencies": {
-    "preact": "6.0.1",
-    "preact-compat": "3.0.0",
+    "preact": "6.0.2",
+    "preact-compat": "3.1.0",
     "react": "15.3.1",
     "react-dom": "15.3.1",
     "tiny-emitter": "1.1.0"


### PR DESCRIPTION
rollup 0.35 has a different tree-shaking implementation. File size is not affected