### PR TITLE
Include fetch polyfill and inject Promise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,7 @@ User avatar
 # 1.3.0
 
 A/B test ways to promote comments with top / bottom bar and comments bubble
+
+# 1.4.0
+
+Include `fetch` polyfill and allow `Promise` to be injected

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "guardian-discussion-frontend",
   "projectName": "Discussion::discussion-frontend",
   "description": "Standalone UI for Guardian comments",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "license": "Apache-2.0",
   "repository": "https://github.com/guardian/discussion-frontend",
   "files": [
@@ -28,7 +28,7 @@
     "babel-plugin-transform-react-remove-prop-types": "^0.2.9",
     "babel-preset-es2015": "^6.14.0",
     "babel-preset-react": "^6.11.1",
-    "eslint": "^3.5.0",
+    "eslint": "^3.6.1",
     "eslint-plugin-react": "^6.3.0",
     "express": "^4.14.0",
     "is-file": "^1.0.0",
@@ -58,6 +58,7 @@
     "preact-compat": "3.4.2",
     "react": "15.3.2",
     "react-dom": "15.3.2",
-    "tiny-emitter": "1.1.0"
+    "tiny-emitter": "1.1.0",
+    "whatwg-fetch": "1.0.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -31,9 +31,11 @@ export default function create ({
     /* User information, if null, it tries to get it from discussion API */
     user,
     /* Does the user have a valid guardian user cookie? If so it'll get the profile from API */
-    userFromCookie
+    userFromCookie,
+    /* Dependency injection: Promise */
+    Promise = window.Promise
 }) {
-    const api = createApi({ apiHost, net });
+    const api = createApi({ apiHost, net, Promise });
 
     const component = (
         <Discussion

--- a/src/net/discussion-api.js
+++ b/src/net/discussion-api.js
@@ -1,11 +1,13 @@
-import * as defaultNet from '../utils/net';
+import { inject } from '../utils/net';
 import mediator from '../utils/mediator';
 import { join } from '../utils/url';
 
 export function create ({
     apiHost,
-    net
+    net,
+    Promise
 }) {
+    const defaultNet = inject(Promise);
     const {json = defaultNet.json, jsonp = defaultNet.jsonp} = net;
 
     function commentCount (...ids) {

--- a/src/utils/net.js
+++ b/src/utils/net.js
@@ -1,21 +1,27 @@
-export function json (path) {
-    return fetch(path, {
-        mode: 'cors'
-    }).then(resp => {
-        return resp.ok ? resp.json() : Promise.reject(new Error('fetch error: ' + resp.statusText));
-    });
-}
+import 'whatwg-fetch';
 
-export function jsonp (path) {
-    return new Promise(function(resolve, reject) {
-        const jsonpCallback = 'jp_' + Math.floor((Math.random() * 100)) + new Date().getTime();
-        const jsonpPath = [path, 'callback=' + jsonpCallback].join(path.indexOf('?') === -1 ? '?' : '&');
-        window[jsonpCallback] = resolve;
-        const script = document.createElement('script');
-        script.src = jsonpPath;
-        script.onerror = function() {
-            reject(new Error('JSONP network error on ' + jsonpPath));
-        };
-        document.head.appendChild(script);
-    });
+export function inject (Promise) {
+    function json (path) {
+        return fetch(path, {
+            mode: 'cors'
+        }).then(resp => {
+            return resp.ok ? resp.json() : Promise.reject(new Error('fetch error: ' + resp.statusText));
+        });
+    }
+
+    function jsonp (path) {
+        return new Promise(function(resolve, reject) {
+            const jsonpCallback = 'jp_' + Math.floor((Math.random() * 100)) + new Date().getTime();
+            const jsonpPath = [path, 'callback=' + jsonpCallback].join(path.indexOf('?') === -1 ? '?' : '&');
+            window[jsonpCallback] = resolve;
+            const script = document.createElement('script');
+            script.src = jsonpPath;
+            script.onerror = function() {
+                reject(new Error('JSONP network error on ' + jsonpPath));
+            };
+            document.head.appendChild(script);
+        });
+    }
+
+    return { json, jsonp };
 }


### PR DESCRIPTION
It'll allow any browser to run discussion frontend.

The other options were:

- use `utils/fetch` -> internally uses `reqwest` which sends a `X-Requested-With` by default and cannot be disabled. Comments API is not configured to allow that header in a CORS request
- use `fetch` from polyfill.io (guardianfill.io?) but there are some issues to be fixed
