### PR TITLE
Update react and preact

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,11 +25,11 @@
   },
   "devDependencies": {
     "babel-plugin-external-helpers": "^6.8.0",
-    "babel-plugin-transform-react-remove-prop-types": "^0.2.9",
+    "babel-plugin-transform-react-remove-prop-types": "^0.2.11",
     "babel-preset-es2015": "^6.14.0",
     "babel-preset-react": "^6.11.1",
-    "eslint": "^3.6.1",
-    "eslint-plugin-react": "^6.3.0",
+    "eslint": "^3.11.0",
+    "eslint-plugin-react": "^6.7.1",
     "express": "^4.14.0",
     "is-file": "^1.0.0",
     "junk": "^2.0.0",
@@ -37,9 +37,9 @@
     "node-riffraff-artefact": "^1.8.0",
     "postcss-calc": "^5.3.1",
     "postcss-modules": "^0.5.2",
-    "postcss-scss": "^0.3.0",
+    "postcss-scss": "^0.4.0",
     "precss": "^1.4.0",
-    "rollup": "^0.36.0",
+    "rollup": "^0.36.4",
     "rollup-plugin-alias": "^1.2.0",
     "rollup-plugin-babel": "^2.6.1",
     "rollup-plugin-commonjs": "^4.1.0",
@@ -48,17 +48,17 @@
     "rollup-plugin-postcss": "^0.2.0",
     "rollup-plugin-replace": "^1.1.1",
     "rollup-plugin-string": "^2.0.2",
-    "stylelint": "^7.3.1",
-    "stylelint-config-standard": "^13.0.2",
-    "uglify-js": "2.7.3"
+    "stylelint": "^7.6.0",
+    "stylelint-config-standard": "^15.0.0",
+    "uglify-js": "2.7.4"
   },
   "dependencies": {
     "intersection-observer": "0.1.1",
-    "preact": "6.0.2",
-    "preact-compat": "3.4.2",
-    "react": "15.3.2",
-    "react-dom": "15.3.2",
+    "preact": "6.4.0",
+    "preact-compat": "3.9.2",
+    "react": "15.4.1",
+    "react-dom": "15.4.1",
     "tiny-emitter": "1.1.0",
-    "whatwg-fetch": "1.0.0"
+    "whatwg-fetch": "2.0.1"
   }
 }

--- a/rollup.base.config.js
+++ b/rollup.base.config.js
@@ -43,17 +43,17 @@ const base = [
     }),
     commonjs({
         namedExports: {
-            'node_modules/react/lib/ReactDOM.js': ['render', 'unmountComponentAtNode'],
-            'node_modules/react/lib/ReactMount.js': ['render', 'unmountComponentAtNode'],
+            'node_modules/react-dom/lib/ReactDOM.js': ['render', 'unmountComponentAtNode'],
+            'node_modules/react-dom/lib/ReactMount.js': ['render', 'unmountComponentAtNode'],
         }
     })
 ];
 
 const aliasesReact = [
     alias({
-        'react-mount': path.join(__dirname, 'node_modules/react/lib/ReactMount.js'),
-        './ReactDefaultInjection': path.join(__dirname, 'node_modules/react/lib/ReactDefaultInjection.js'),
-        './ReactMount': path.join(__dirname, 'node_modules/react/lib/ReactMount.js'),
+        'react-mount': path.join(__dirname, 'node_modules/react-dom/lib/ReactMount.js'),
+        './ReactDefaultInjection': path.join(__dirname, 'node_modules/react-dom/lib/ReactDefaultInjection.js'),
+        './ReactMount': path.join(__dirname, 'node_modules/react-dom/lib/ReactMount.js'),
         './ReactClass': path.join(__dirname, 'bin/lib/react-class-prod.js'),
         // disable animation and transition events with vendor prefixes
         './getVendorPrefixedEventName': path.join(__dirname, 'bin/lib/react-get-vendor-prefixed-event-name-prod.js')
@@ -68,7 +68,7 @@ const aliasesPreact = [
 ];
 
 const excludeBabel = [
-    'node_modules/react/**', 'node_modules/fbjs/**',
+    'node_modules/react/**', 'node_modules/react-dom/**', 'node_modules/fbjs/**',
     'node_modules/proptypes/**',
     '**/*.css', '**/*.svg', '**/*.html'
 ];
@@ -98,7 +98,7 @@ const development = [
         'process.env.NODE_ENV': '\'development\''
     }),
     alias({
-        'react-dom': path.join(__dirname, 'node_modules/react/lib/ReactDOM.js')
+        'react-dom': path.join(__dirname, 'node_modules/react-dom/lib/ReactDOM.js')
     }),
     babel({
         exclude: excludeBabel


### PR DESCRIPTION
Preact was easy, React instead moved a bunch of code around so the rollup configuration had to change.

There's little difference in file size, preact gets 300B more, react looses 400B

As you can imagine, I can't test the changes inside dotcom frontend, I've only tested in the mock environment