### PR TITLE
Add Preact UMD bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "clean": "rm -rf tmp && mkdir -p tmp && rm -rf dist",
-    "compile": "rollup -c rollup.config.react.amd.js && rollup -c rollup.config.preact.amd.js",
+    "compile": "rollup -c rollup.config.react.amd.js && rollup -c rollup.config.preact.amd.js && rollup -c rollup.config.preact.umd.js",
     "hash": "node bin/hash.js",
     "deploy": "node bin/riffraff.js",
     "lint": "eslint src test && stylelint 'src/**/*.css'",

--- a/rollup.config.preact.umd.js
+++ b/rollup.config.preact.umd.js
@@ -1,0 +1,12 @@
+const plugins = require('./rollup.base.config').standalonePreactProduction;
+
+const config = {
+    entry: 'src/index.js',
+    format: 'umd',
+    moduleName: 'guardian.app.discussion',
+    dest: 'dist/discussion-frontend.preact.umd.js',
+    sourceMap: true,
+    plugins: plugins
+};
+
+export default config;


### PR DESCRIPTION
As discussed in #20, the Frontend is moving away from using Curl JS to load and execute JavaScript modules. As a result, external scripts should not assume the existence of a global `define` function.

This change adds a Preact bundle with a UMD output format. This can be loaded by the Frontend using the [`load-script`](https://github.com/guardian/frontend/blob/master/static/src/javascripts-legacy/projects/common/utils/load-script.js) module and then consuming the exportable via the global object.

c/c @sndrs @piuccio 