### PR TITLE
Update change password link on example page

### DIFF
--- a/example/article.html
+++ b/example/article.html
@@ -37,7 +37,7 @@ Saved for later</a>
 <li class="popup__item"><a class="brand-bar__item--action js-comment-activity" data-link-name="Comment activity" href="https://profile.theguardian.com/user/id/13975520">Comment activity</a></li>
 <li class="popup__item"><a href="https://profile.theguardian.com/public/edit" class="brand-bar__item--action" data-link-name="Edit profile">Edit profile</a></li>
 <li class="popup__item"><a href="https://profile.theguardian.com/email-prefs" class="brand-bar__item--action" data-link-name="Email preferences">Email preferences</a></li>
-<li class="popup__item"><a href="https://profile.theguardian.com/password/change" class="brand-bar__item--action" data-link-name="Change password">Change password</a></li>
+<li class="popup__item"><a href="https://profile.theguardian.com/reset" class="brand-bar__item--action" data-link-name="Change password">Change password</a></li>
 <li class="popup__item"><a href="https://profile.theguardian.com/signout" class="brand-bar__item--action" data-link-name="Sign out">Sign out</a></li>
 </ul>
 </div>


### PR DESCRIPTION
## What does this change?
This updates the change password link in the example page to point to the correct password reset page. The page the link is currently pointing at will shortly be removed to reduce duplication and ensure we are adhering to security best practice.