### PR TITLE
Add archive note

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> Note
+> This project has been archived, and most of it's goals have bee achieved via https://github.com/guardian/discussion-rendering
+
 Standalone UI for Guardian comments
 
 # Install


### PR DESCRIPTION
Adds a note saying that most of the goals of this project have now been superseded by  https://github.com/guardian/discussion-rendering